### PR TITLE
Fix typo in docs

### DIFF
--- a/ast/src/main/scala/pl/msitko/xml/entities/AST.scala
+++ b/ast/src/main/scala/pl/msitko/xml/entities/AST.scala
@@ -118,7 +118,7 @@ final case class DoctypeDeclaration(text: String)
   *
   * That means that comments and processing instructions that are placed after the root element cannot be
   * expressed using xml-lens AST. Mind that it does not apply to comments and processing instructions which
-  * are places outside of root element but before it. Those items can be expressed in terms of xml-lens AST
+  * are placed outside of root element but before it. Those items can be expressed in terms of xml-lens AST
   * as part of Prolog.
   */
 final case class XmlDocument(prolog: Prolog, root: LabeledElement)

--- a/docs/src/main/tut/docs/quickstart.md
+++ b/docs/src/main/tut/docs/quickstart.md
@@ -13,8 +13,8 @@ Add following lines to your `build.sbt`:
 
 ```
 libraryDependencies ++= Seq(
-	"pl.msitko" %% "xml-lens-io"     % "0.1.0-RC6",
-	"pl.msitko" %% "xml-lens-optics" % "0.1.0-RC6"
+	"pl.msitko" %% "xml-lens-io"     % "0.1.0",
+	"pl.msitko" %% "xml-lens-optics" % "0.1.0"
 )
 ```
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -158,7 +158,7 @@ document  ::=  prolog element
 
 That means that comments and processing instructions that are placed after the root element cannot be
 expressed using `xml-lens` AST. Mind that it does not apply to comments and processing instructions which
-are places outside of root element but before it. Those items can be expressed in terms of `xml-lens` AST
+are placed outside of root element but before it. Those items can be expressed in terms of `xml-lens` AST
 as part of `Prolog`.
 
 ## License


### PR DESCRIPTION
Follow up of https://github.com/note/xml-lens/pull/36/files