### PR TITLE
Fix broken links for modularity and optics chapter

### DIFF
--- a/docs/src/main/tut/docs/quickstart.md
+++ b/docs/src/main/tut/docs/quickstart.md
@@ -100,7 +100,7 @@ XmlPrinter.print(res)
 
 ### Where should I go from here
 
-Recommended next reading is [chapter](docs/modularity.html) on modularity and [chapter](docs/optics.html)
+Recommended next reading is [chapter](modularity.html) on modularity and [chapter](optics.html)
 covering Optics API. Those chapters will help you understanding how `xml-lens` API is structured.
 
 In case of specific questions take a look at other chapters of this docs.


### PR DESCRIPTION
While going through the documentation I found that the links were broken. These are the broken links that appear: https://note.github.io/xml-lens/docs/docs/modularity.html there is an extra `docs` in the path. This should fix it